### PR TITLE
hydra: github-runner: remediate the __noChroot darwin issue

### DIFF
--- a/hosts/hydra/github-runner.nix
+++ b/hosts/hydra/github-runner.nix
@@ -1,4 +1,6 @@
-{ config, ... }:
+# FIXME: Get rid of GitHub(-runner)
+
+{ config, pkgs, ... }:
 {
   sops.secrets.gh-runner-token = { };
 
@@ -8,5 +10,9 @@
     tokenFile = config.sops.secrets.gh-runner-token.path;
     replace = true;
     user = "nix";
+    package = pkgs.github-runner.overrideAttrs (_: {
+        # Remediate https://github.com/NixOS/nixpkgs/pull/506237#discussion_r3052699154
+        __noChroot = false;
+    });
   };
 }


### PR DESCRIPTION
Deployed for the lock file bump