### PR TITLE
helpers: Add clone-pr command

### DIFF
--- a/packages/helpers/Cargo.lock
+++ b/packages/helpers/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sha2",
+ "url",
 ]
 
 [[package]]

--- a/packages/helpers/Cargo.toml
+++ b/packages/helpers/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 serde_repr = "0.1.20"
 sha2 = "0.10.9"
+url = "2.5.8"

--- a/packages/helpers/src/main.rs
+++ b/packages/helpers/src/main.rs
@@ -210,7 +210,7 @@ fn make_app_jwt(client_id: String, key: rsa::RsaPrivateKey) -> AppToken {
 fn get_installation_for_repo(
     http_client: &reqwest::blocking::Client,
     app_token: &AppToken,
-    repo_full_name: &String,
+    repo_full_name: &str,
 ) -> Result<u64> {
     #[derive(serde::Deserialize)]
     struct Response {
@@ -259,8 +259,8 @@ fn get_installation_token(
 fn sync_branch(
     http_client: &reqwest::blocking::Client,
     token: &InstallationToken,
-    repo_full_name: &String,
-    branch_name: &String,
+    repo_full_name: &str,
+    branch_name: &str,
 ) -> Result<()> {
     #[derive(serde::Serialize)]
     struct Request {
@@ -285,9 +285,9 @@ fn sync_branch(
 fn update_branch(
     http_client: &reqwest::blocking::Client,
     token: &InstallationToken,
-    repo_full_name: &String,
-    branch_name: &String,
-    commit_sha: &String,
+    repo_full_name: &str,
+    branch_name: &str,
+    commit_sha: &str,
 ) -> Result<()> {
     #[derive(serde::Serialize)]
     struct Request {
@@ -351,7 +351,7 @@ fn read_hydra_json() -> Result<HydraJson> {
 
 fn get_build_evals(
     client: &reqwest::blocking::Client,
-    hydra_url: &String,
+    hydra_url: &str,
     build_id: u64,
 ) -> Result<Vec<u64>> {
     #[derive(serde::Deserialize)]
@@ -379,7 +379,7 @@ struct JobsetEval {
 
 fn get_eval(
     client: &reqwest::blocking::Client,
-    hydra_url: &String,
+    hydra_url: &str,
     eval_id: u64,
 ) -> Result<JobsetEval> {
     Ok(client

--- a/packages/helpers/src/main.rs
+++ b/packages/helpers/src/main.rs
@@ -34,13 +34,22 @@ enum Commands {
 fn main() -> Result<()> {
     use clap::Parser;
     let cli = Cli::parse();
-    let get_app_token = move || -> Result<AppToken> {
+    let get_token = move |client: &reqwest::blocking::Client,
+                          repo_full_name: &str|
+          -> Result<InstallationToken> {
         use rsa::pkcs1::DecodeRsaPrivateKey;
         let private_key =
             rsa::RsaPrivateKey::read_pkcs1_pem_file(&cli.private_key).with_context(|| {
                 format!("failed to read private key from file {:?}", cli.private_key)
             })?;
-        Ok(make_app_jwt(cli.client_id, private_key))
+        let app_token = make_app_jwt(cli.client_id, private_key);
+        let installation_id = get_installation_for_repo(client, &app_token, repo_full_name)
+            .with_context(|| {
+                format!("failed to get GitHub app installation for repo {repo_full_name}")
+            })?;
+        let installation_token = get_installation_token(client, &app_token, installation_id)
+            .with_context(|| format!("failed to get token for installation {installation_id}"))?;
+        Ok(installation_token)
     };
     match cli.command {
         Commands::UpdateChannel {
@@ -49,7 +58,7 @@ fn main() -> Result<()> {
             upstream_branch,
             branch,
         } => update_channel(
-            get_app_token,
+            get_token,
             hydra_url,
             repo_full_name,
             upstream_branch,
@@ -58,12 +67,12 @@ fn main() -> Result<()> {
         Commands::SyncBranches {
             repo_full_name,
             branches,
-        } => sync_branches(get_app_token, repo_full_name, branches),
+        } => sync_branches(get_token, repo_full_name, branches),
     }
 }
 
 fn sync_branches(
-    get_app_token: impl FnOnce() -> Result<AppToken>,
+    get_token: impl FnOnce(&reqwest::blocking::Client, &str) -> Result<InstallationToken>,
     repo_full_name: String,
     branches: Vec<String>,
 ) -> Result<()> {
@@ -76,17 +85,11 @@ fn sync_branches(
         ))
         .build()?;
 
-    let app_token = get_app_token()?;
-    let installation_id = get_installation_for_repo(&client, &app_token, &repo_full_name)
-        .with_context(|| {
-            format!("failed to get GitHub app installation for repo {repo_full_name}")
-        })?;
-    let installation_token = get_installation_token(&client, &app_token, installation_id)
-        .with_context(|| format!("failed to get token for installation {installation_id}"))?;
+    let token = get_token(&client, &repo_full_name)?;
 
     let mut has_errors = false;
     for branch in branches {
-        if let Err(err) = sync_branch(&client, &installation_token, &repo_full_name, &branch) {
+        if let Err(err) = sync_branch(&client, &token, &repo_full_name, &branch) {
             eprintln!(
                 "failed to sync branch {branch} in repo {repo_full_name} with the upstream: {err}"
             );
@@ -101,7 +104,7 @@ fn sync_branches(
 }
 
 fn update_channel(
-    get_app_token: impl FnOnce() -> Result<AppToken>,
+    get_token: impl FnOnce(&reqwest::blocking::Client, &str) -> Result<InstallationToken>,
     hydra_url: String,
     repo_full_name: String,
     upstream_branch: String,
@@ -148,30 +151,11 @@ fn update_channel(
     );
 
     // Update branch
-    let app_token = get_app_token()?;
-    let installation_id = get_installation_for_repo(&client, &app_token, &repo_full_name)
-        .with_context(|| {
-            format!("failed to get GitHub app installation for repo {repo_full_name}")
-        })?;
-    let installation_token = get_installation_token(&client, &app_token, installation_id)
-        .with_context(|| format!("failed to get token for installation {installation_id}"))?;
-    sync_branch(
-        &client,
-        &installation_token,
-        &repo_full_name,
-        &upstream_branch,
-    )
-    .with_context(|| {
+    let token = get_token(&client, &repo_full_name)?;
+    sync_branch(&client, &token, &repo_full_name, &upstream_branch).with_context(|| {
         format!("failed to sync branch {branch} in repo {repo_full_name} with the upstream")
     })?;
-    update_branch(
-        &client,
-        &installation_token,
-        &repo_full_name,
-        &branch,
-        &commit_sha,
-    )
-    .with_context(|| {
+    update_branch(&client, &token, &repo_full_name, &branch, &commit_sha).with_context(|| {
         format!("failed to update branch {branch} in repo {repo_full_name} to commit {commit_sha}")
     })?;
     eprintln!("updated branch {branch} in repo {repo_full_name} to commit {commit_sha}");

--- a/packages/helpers/src/main.rs
+++ b/packages/helpers/src/main.rs
@@ -5,10 +5,10 @@ use anyhow::{Context, Result, anyhow};
 struct Cli {
     #[command(subcommand)]
     command: Commands,
-    #[arg(long)]
-    client_id: String,
-    #[arg(long)]
-    private_key: std::path::PathBuf,
+    #[arg(long, requires = "private_key")]
+    client_id: Option<String>,
+    #[arg(long, requires = "client_id")]
+    private_key: Option<std::path::PathBuf>,
 }
 
 #[derive(clap::Subcommand)]
@@ -36,20 +36,53 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     let get_token = move |client: &reqwest::blocking::Client,
                           repo_full_name: &str|
-          -> Result<InstallationToken> {
-        use rsa::pkcs1::DecodeRsaPrivateKey;
-        let private_key =
-            rsa::RsaPrivateKey::read_pkcs1_pem_file(&cli.private_key).with_context(|| {
-                format!("failed to read private key from file {:?}", cli.private_key)
-            })?;
-        let app_token = make_app_jwt(cli.client_id, private_key);
-        let installation_id = get_installation_for_repo(client, &app_token, repo_full_name)
-            .with_context(|| {
-                format!("failed to get GitHub app installation for repo {repo_full_name}")
-            })?;
-        let installation_token = get_installation_token(client, &app_token, installation_id)
-            .with_context(|| format!("failed to get token for installation {installation_id}"))?;
-        Ok(installation_token)
+          -> Result<InstallationOrUserToken> {
+        Ok(InstallationOrUserToken(
+            match (cli.client_id, cli.private_key) {
+                (None, None) => {
+                    std::env::var("GITHUB_TOKEN").or_else(|err| match err {
+                        std::env::VarError::NotPresent => {
+                            eprintln!(
+                                "GITHUB_TOKEN environment variable is not set, trying `gh auth token`"
+                            );
+                            let stdout = std::process::Command::new("gh")
+                                .args(["auth", "token"])
+                                .stderr(std::process::Stdio::inherit())
+                                .output()
+                                .context("failed to run `gh auth token`")?
+                                .stdout;
+                            // Trim trailing newline from stdout
+                            Ok(String::from_utf8_lossy(&stdout[..stdout.len() - 1]).to_string())
+                        }
+                        std::env::VarError::NotUnicode(_) => {
+                            Err(anyhow!(err).context("couldn't parse GITHUB_TOKEN environment variable"))
+                        }
+                    })?
+                }
+                (Some(client_id), Some(private_key)) => {
+                    use rsa::pkcs1::DecodeRsaPrivateKey;
+                    let private_key = rsa::RsaPrivateKey::read_pkcs1_pem_file(&private_key)
+                        .with_context(|| {
+                            format!("failed to read private key from file {:?}", private_key)
+                        })?;
+                    let app_token = make_app_jwt(client_id, private_key);
+                    let installation_id = get_installation_for_repo(
+                        client,
+                        &app_token,
+                        repo_full_name,
+                    )
+                    .with_context(|| {
+                        format!("failed to get GitHub app installation for repo {repo_full_name}")
+                    })?;
+                    let installation_token =
+                        get_installation_token(client, &app_token, installation_id).with_context(
+                            || format!("failed to get token for installation {installation_id}"),
+                        )?;
+                    installation_token.0
+                }
+                (None, Some(_)) | (Some(_), None) => unreachable!("enforced by clap"),
+            },
+        ))
     };
     match cli.command {
         Commands::UpdateChannel {
@@ -72,7 +105,7 @@ fn main() -> Result<()> {
 }
 
 fn sync_branches(
-    get_token: impl FnOnce(&reqwest::blocking::Client, &str) -> Result<InstallationToken>,
+    get_token: impl FnOnce(&reqwest::blocking::Client, &str) -> Result<InstallationOrUserToken>,
     repo_full_name: String,
     branches: Vec<String>,
 ) -> Result<()> {
@@ -91,7 +124,7 @@ fn sync_branches(
     for branch in branches {
         if let Err(err) = sync_branch(&client, &token, &repo_full_name, &branch) {
             eprintln!(
-                "failed to sync branch {branch} in repo {repo_full_name} with the upstream: {err}"
+                "failed to sync branch {branch} in repo {repo_full_name} with the upstream: {err:?}"
             );
             has_errors = true;
         }
@@ -104,7 +137,7 @@ fn sync_branches(
 }
 
 fn update_channel(
-    get_token: impl FnOnce(&reqwest::blocking::Client, &str) -> Result<InstallationToken>,
+    get_token: impl FnOnce(&reqwest::blocking::Client, &str) -> Result<InstallationOrUserToken>,
     hydra_url: String,
     repo_full_name: String,
     upstream_branch: String,
@@ -164,6 +197,7 @@ fn update_channel(
 
 struct AppToken(String);
 struct InstallationToken(String);
+struct InstallationOrUserToken(String);
 
 /// Generate GitHub app token (JWT) from its private key.
 /// https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
@@ -242,7 +276,7 @@ fn get_installation_token(
 /// https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository
 fn sync_branch(
     http_client: &reqwest::blocking::Client,
-    token: &InstallationToken,
+    token: &InstallationOrUserToken,
     repo_full_name: &str,
     branch_name: &str,
 ) -> Result<()> {
@@ -268,7 +302,7 @@ fn sync_branch(
 /// https://docs.github.com/rest/git/refs#update-a-reference
 fn update_branch(
     http_client: &reqwest::blocking::Client,
-    token: &InstallationToken,
+    token: &InstallationOrUserToken,
     repo_full_name: &str,
     branch_name: &str,
     commit_sha: &str,

--- a/packages/helpers/src/main.rs
+++ b/packages/helpers/src/main.rs
@@ -181,6 +181,8 @@ fn update_channel(
 struct AppToken(String);
 struct InstallationToken(String);
 
+/// Generate GitHub app token (JWT) from its private key.
+/// https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
 fn make_app_jwt(client_id: String, key: rsa::RsaPrivateKey) -> AppToken {
     use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     let signer = rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new(key);
@@ -203,6 +205,8 @@ fn make_app_jwt(client_id: String, key: rsa::RsaPrivateKey) -> AppToken {
     AppToken(to_sign + "." + &signature)
 }
 
+/// Get GitHub app installation ID for repository.
+/// https://docs.github.com/en/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app
 fn get_installation_for_repo(
     http_client: &reqwest::blocking::Client,
     app_token: &AppToken,
@@ -223,6 +227,8 @@ fn get_installation_for_repo(
         .id)
 }
 
+/// Get GitHub app's installation access token.
+/// https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app
 fn get_installation_token(
     http_client: &reqwest::blocking::Client,
     app_token: &AppToken,
@@ -248,6 +254,8 @@ fn get_installation_token(
     Ok(InstallationToken(resp.token))
 }
 
+/// Sync branch in a GitHub fork with the upstream repository.
+/// https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository
 fn sync_branch(
     http_client: &reqwest::blocking::Client,
     token: &InstallationToken,
@@ -271,6 +279,9 @@ fn sync_branch(
     Ok(())
 }
 
+/// Update branch on GitHub repo to the specified commit.
+/// The commit must be present in this fork.
+/// https://docs.github.com/rest/git/refs#update-a-reference
 fn update_branch(
     http_client: &reqwest::blocking::Client,
     token: &InstallationToken,

--- a/packages/helpers/src/main.rs
+++ b/packages/helpers/src/main.rs
@@ -29,6 +29,13 @@ enum Commands {
         #[arg(num_args=1..)]
         branches: Vec<String>,
     },
+    ClonePR {
+        #[arg(long, default_value = "nixos-cuda/nixpkgs")]
+        repo_full_name: String,
+        #[arg(long, default_value = "Clone of {html_url} for CI")]
+        body: String,
+        pr_url: reqwest::Url,
+    },
 }
 
 fn main() -> Result<()> {
@@ -101,7 +108,59 @@ fn main() -> Result<()> {
             repo_full_name,
             branches,
         } => sync_branches(get_token, repo_full_name, branches),
+        Commands::ClonePR {
+            repo_full_name,
+            body,
+            pr_url,
+        } => clone_pr(get_token, repo_full_name, body, pr_url),
     }
+}
+
+fn clone_pr(
+    get_token: impl FnOnce(&reqwest::blocking::Client, &str) -> Result<InstallationOrUserToken>,
+    repo_full_name: String,
+    body: String,
+    pr_url: reqwest::Url,
+) -> Result<()> {
+    if pr_url
+        .host()
+        .is_none_or(|host| host != url::Host::Domain("github.com"))
+        || pr_url.scheme() != "https"
+    {
+        return Err(anyhow!("PR URL must start with https://github.com"));
+    }
+    let ["", org, repo, "pull", pr_num_str] = pr_url.path().split('/').collect::<Vec<_>>()[..]
+    else {
+        return Err(anyhow!("PR URL path must be /<org>/<repo>/pull/<pr_num>"));
+    };
+    let upstream_repo_full_name = format!("{org}/{repo}");
+    let pr_num = pr_num_str.parse().context("couldn't parse PR number")?;
+
+    // Prepare HTTP client
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(concat!(
+            env!("CARGO_PKG_NAME"),
+            "/",
+            env!("CARGO_PKG_VERSION"),
+        ))
+        .build()?;
+
+    let token = get_token(&client, &repo_full_name)?;
+    let pr = get_pr(&client, &token, &upstream_repo_full_name, pr_num)?;
+    let head = format!("{}:{}", pr.head.repo.owner.login, pr.head.r#ref);
+    let new_pr = create_pr(
+        &client,
+        &token,
+        &repo_full_name,
+        &pr.title,
+        &head,
+        &pr.head.repo.full_name,
+        &pr.base.r#ref,
+        &body.replace("{html_url}", &pr.html_url),
+    )?;
+    eprintln!("Created a new PR {}", new_pr.html_url);
+
+    Ok(())
 }
 
 fn sync_branches(
@@ -324,6 +383,90 @@ fn update_branch(
         .send()?
         .error_for_status_with_body()?;
     Ok(())
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct SimpleUser {
+    login: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct Repository {
+    full_name: String,
+    owner: SimpleUser,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct PullRequestBase {
+    r#ref: String,
+    repo: Repository,
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct PullRequest {
+    html_url: String,
+    title: String,
+    head: PullRequestBase,
+    base: PullRequestBase,
+}
+
+/// Get PR object from PR number
+/// https://docs.github.com/rest/pulls/pulls#get-a-pull-request
+fn get_pr(
+    http_client: &reqwest::blocking::Client,
+    token: &InstallationOrUserToken,
+    repo_full_name: &str,
+    pr_num: u64,
+) -> Result<PullRequest> {
+    Ok(http_client
+        .get(format!(
+            "https://api.github.com/repos/{repo_full_name}/pulls/{pr_num}",
+        ))
+        .bearer_auth(&token.0)
+        .send()?
+        .error_for_status_with_body()?
+        .json()?)
+}
+
+/// Create GitHub pull request
+/// https://docs.github.com/rest/pulls/pulls#create-a-pull-request
+#[allow(clippy::too_many_arguments)]
+fn create_pr(
+    http_client: &reqwest::blocking::Client,
+    token: &InstallationOrUserToken,
+    repo_full_name: &str,
+    title: &str,
+    head: &str,
+    head_repo: &str,
+    base: &str,
+    body: &str,
+) -> Result<PullRequest> {
+    #[derive(serde::Serialize, Debug)]
+    struct Request<'a> {
+        title: &'a str,
+        head: &'a str,
+        head_repo: &'a str,
+        base: &'a str,
+        body: &'a str,
+        maintainer_can_modify: bool,
+    }
+    let request = Request {
+        title,
+        head,
+        head_repo,
+        base,
+        body,
+        maintainer_can_modify: false,
+    };
+    Ok(http_client
+        .post(format!(
+            "https://api.github.com/repos/{repo_full_name}/pulls",
+        ))
+        .bearer_auth(&token.0)
+        .json(&request)
+        .send()?
+        .error_for_status_with_body()?
+        .json()?)
 }
 
 #[derive(serde_repr::Deserialize_repr, Debug, PartialEq)]


### PR DESCRIPTION
Allows the user to clone any PR into another repo.
Also add `--use-gh-token` flag to use user's token from `GITHUB_TOKEN` env variable or `gh auth token` to not overcomplicate things with GH Apps.

Example usage for common use case of running Hydra jobset on upstream PR:

```
nix run .#helpers -- --use-gh-token clone-pr --body 'Clone of {html_url} for CI' --repo-full-name nixos-cuda/nixpkgs https://github.com/NixOS/nixpkgs/pull/513905
