### PR TITLE
harmonia: run over unix domain sockets; use unstable version

### DIFF
--- a/hosts/hydra/cache.nix
+++ b/hosts/hydra/cache.nix
@@ -2,30 +2,26 @@
 {
   sops.secrets.harmonia-private-key = { };
 
-  services =
-    let
-      port = "5000";
-    in
-    {
-      harmonia = {
-        enable = true;
+  services = {
+    harmonia = {
+      enable = true;
 
-        signKeyPaths = [
-          # Public key: cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=
-          config.sops.secrets.harmonia-private-key.path
-        ];
+      signKeyPaths = [
+        # Public key: cache.nixos-cuda.org:74DUi4Ye579gUqzH4ziL9IyiJBlDpMRn9MBN8oNan9M=
+        config.sops.secrets.harmonia-private-key.path
+      ];
 
-        settings = {
-          bind = "localhost:${port}";
+      settings = {
+        bind = "/run/harmonia/socket";
 
-          # Pick a lower priority (higher number) than cache.nixos.org
-          # https://cache.nixos.org/nix-cache-info
-          priority = 50;
-        };
+        # Pick a lower priority (higher number) than cache.nixos.org
+        # https://cache.nixos.org/nix-cache-info
+        priority = 50;
       };
-
-      caddy.virtualHosts."cache.nixos-cuda.org".extraConfig = ''
-        reverse_proxy localhost:${port}
-      '';
     };
+
+    caddy.virtualHosts."cache.nixos-cuda.org".extraConfig = ''
+      reverse_proxy unix//run/harmonia/socket
+    '';
+  };
 }

--- a/hosts/hydra/grafana.nix
+++ b/hosts/hydra/grafana.nix
@@ -71,9 +71,10 @@ in
         # Not available in the latest release: https://github.com/nix-community/harmonia/issues/631
         {
           job_name = "harmonia";
+          scheme = "https";
           static_configs = [
             {
-              targets = [ config.services.harmonia.settings.bind ];
+              targets = [ "cache.nixos-cuda.org" ];
             }
           ];
         }


### PR DESCRIPTION
Not traversing the network stack twice is generally more efficient.

Also bumps harmonia to the current nixos-unstable version.

https://github.com/nix-community/harmonia/releases/tag/harmonia-v3.0.0
https://github.com/nix-community/harmonia/releases/tag/harmonia-v3.1.0 (faster narinfo delivery)
