### PR TITLE
hydra: Sync PRs from NixOS/nixpkgs to nixos-cuda/nixpkgs

### DIFF
--- a/hosts/hydra/default.nix
+++ b/hosts/hydra/default.nix
@@ -10,6 +10,7 @@
     ./hydra
     ./hydra-github-app.nix
     ./sync-nixpkgs-branches.nix
+    ./sync-cuda-prs.nix
   ];
 
   networking.hostId = "e1ce6466";

--- a/hosts/hydra/sync-cuda-prs.nix
+++ b/hosts/hydra/sync-cuda-prs.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+let
+  users = [
+    "ConnorBaker"
+    "GaetanLepage"
+    "SomeoneSerge"
+    "YorikSar"
+  ];
+  serviceName = "sync-cuda-prs";
+  helpers = pkgs.lib.getExe inputs.self.packages.${config.nixpkgs.system}.helpers;
+  script = lib.concatStringsSep " " (
+    [
+      helpers
+
+      # channel-updater GitHub app client ID
+      "--client-id"
+      "Iv23liZJuJFjr3N1KsP0"
+
+      # Path to the channel-updater Github app key file
+      "--private-key"
+      "$CREDENTIALS_DIRECTORY/github_app_key"
+
+      "sync-prs"
+
+      # from upstream repo
+      "--upstream-repo-full-name"
+      "NixOS/nixpkgs"
+
+      # to nixpkgs fork
+      "--repo-full-name"
+      "nixos-cuda/nixpkgs"
+
+      # body for new PRs
+      "--body"
+      "Clone of {html_url} for CI"
+
+      # scan last 100 PRs
+      "--top"
+      "100"
+    ]
+    ++ (lib.concatMap (user: [
+      "--from-users"
+      user
+    ]) users)
+  );
+in
+{
+  systemd.timers.${serviceName} = {
+    wantedBy = [ "timers.target" ];
+    timerConfig.OnCalendar = "*:1/5"; # every 5 minutes
+    timerConfig.Unit = "${serviceName}.service";
+  };
+  systemd.services.${serviceName} = {
+    inherit script;
+    serviceConfig = {
+      Type = "oneshot";
+      DynamicUser = true;
+      LoadCredential = [
+        "github_app_key:${config.sops.secrets.channel-updater-github-app-key.path}"
+      ];
+    };
+  };
+}

--- a/packages/helpers/Cargo.lock
+++ b/packages/helpers/Cargo.lock
@@ -371,6 +371,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +554,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "itertools",
  "reqwest",
  "rsa",
  "serde",
@@ -792,6 +799,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"

--- a/packages/helpers/Cargo.toml
+++ b/packages/helpers/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.100"
 base64 = "0.22.1"
 chrono = { version = "0.4.42", default-features = false, features = ["std", "now", "serde"] }
 clap = { version = "4.6.0", features = ["derive"] }
+itertools = "0.14.0"
 reqwest = { version = "0.13.1", features = ["blocking", "gzip", "json", "query"] }
 rsa = { version = "0.9.9", features = ["sha2"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/packages/helpers/src/main.rs
+++ b/packages/helpers/src/main.rs
@@ -568,6 +568,16 @@ trait ResponseErrorWithBody {
     where
         Self: Sized;
 }
+#[derive(Debug)]
+struct ErrorWithBody {
+    body: String,
+}
+impl std::error::Error for ErrorWithBody {}
+impl std::fmt::Display for ErrorWithBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "got response body: {}", self.body)
+    }
+}
 impl ResponseErrorWithBody for reqwest::blocking::Response {
     fn error_for_status_with_body(self) -> Result<Self>
     where
@@ -579,8 +589,8 @@ impl ResponseErrorWithBody for reqwest::blocking::Response {
                 let mut buf = Vec::new();
                 use std::io::Read;
                 self.take(1024).read_to_end(&mut buf)?;
-                let body = String::from_utf8_lossy(&buf);
-                Err(anyhow!("got response body: {}", body).context(err))
+                let body = String::from_utf8_lossy(&buf).into_owned();
+                Err(ErrorWithBody { body }).context(err)
             }
         }
     }

--- a/packages/helpers/src/main.rs
+++ b/packages/helpers/src/main.rs
@@ -147,20 +147,31 @@ fn clone_pr(
 
     let token = get_token(&client, &repo_full_name)?;
     let pr = get_pr(&client, &token, &upstream_repo_full_name, pr_num)?;
+    let new_pr = make_pr_clone(&client, &token, &pr, &repo_full_name, &body)?;
+    eprintln!("Created a new PR {}", new_pr.html_url);
+
+    Ok(())
+}
+
+fn make_pr_clone(
+    client: &reqwest::blocking::Client,
+    token: &InstallationOrUserToken,
+    pr: &PullRequest,
+    repo_full_name: &str,
+    body: &str,
+) -> Result<PullRequest, anyhow::Error> {
     let head = format!("{}:{}", pr.head.repo.owner.login, pr.head.r#ref);
     let new_pr = create_pr(
-        &client,
-        &token,
-        &repo_full_name,
+        client,
+        token,
+        repo_full_name,
         &pr.title,
         &head,
         &pr.head.repo.full_name,
         &pr.base.r#ref,
         &body.replace("{html_url}", &pr.html_url),
     )?;
-    eprintln!("Created a new PR {}", new_pr.html_url);
-
-    Ok(())
+    Ok(new_pr)
 }
 
 fn sync_branches(

--- a/packages/helpers/src/main.rs
+++ b/packages/helpers/src/main.rs
@@ -36,6 +36,21 @@ enum Commands {
         body: String,
         pr_url: reqwest::Url,
     },
+    #[command(name = "sync-prs")]
+    SyncPRs {
+        #[arg(long, default_value = "NixOS/nixpkgs")]
+        upstream_repo_full_name: String,
+        #[arg(long, default_value = "nixos-cuda/nixpkgs")]
+        repo_full_name: String,
+        #[arg(long, default_values = vec!["ConnorBaker", "GaetanLepage", "SomeoneSerge", "YorikSar"])]
+        from_users: Vec<String>,
+        #[arg(long, default_value = "Clone of {html_url} for CI")]
+        body: String,
+        #[arg(long, default_value = "100")]
+        top: usize,
+        #[arg(long, default_value_t)]
+        dont_stop_at_first_existing: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -113,6 +128,22 @@ fn main() -> Result<()> {
             body,
             pr_url,
         } => clone_pr(get_token, repo_full_name, body, pr_url),
+        Commands::SyncPRs {
+            upstream_repo_full_name,
+            repo_full_name,
+            from_users,
+            body,
+            top,
+            dont_stop_at_first_existing,
+        } => sync_prs(
+            get_token,
+            upstream_repo_full_name,
+            repo_full_name,
+            from_users,
+            body,
+            top,
+            dont_stop_at_first_existing,
+        ),
     }
 }
 
@@ -172,6 +203,63 @@ fn make_pr_clone(
         &body.replace("{html_url}", &pr.html_url),
     )?;
     Ok(new_pr)
+}
+
+fn sync_prs(
+    get_token: impl FnOnce(&reqwest::blocking::Client, &str) -> Result<InstallationOrUserToken>,
+    upstream_repo_full_name: String,
+    repo_full_name: String,
+    from_users: Vec<String>,
+    body: String,
+    top: usize,
+    dont_stop_at_first_existing: bool,
+) -> Result<()> {
+    // Prepare HTTP client
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(concat!(
+            env!("CARGO_PKG_NAME"),
+            "/",
+            env!("CARGO_PKG_VERSION"),
+        ))
+        .build()?;
+
+    let token = get_token(&client, &repo_full_name)?;
+
+    for res in get_pulls_iter(&client, &token, &upstream_repo_full_name).take(top) {
+        let Ok(pr) = res else {
+            return res.map(|_| ());
+        };
+        if !matches!(pr.state, PullRequestState::Open) || !from_users.contains(&pr.user.login) {
+            continue;
+        }
+        eprintln!("Found {}", pr.html_url);
+        match make_pr_clone(&client, &token, &pr, &repo_full_name, &body) {
+            Ok(new_pr) => eprintln!("Created a new PR {}", new_pr.html_url),
+            Err(err) => match err.downcast_ref::<ErrorWithBody>() {
+                Some(body_err)
+                    if matches!(err.downcast_ref::<reqwest::Error>(),
+                    Some(http_err) if matches!(http_err.status(),
+                        Some(reqwest::StatusCode::UNPROCESSABLE_ENTITY)
+                    )) =>
+                {
+                    if !body_err.body.contains("A pull request already exists for") {
+                        return Err(err);
+                    }
+                    eprintln!(
+                        "A pull request already exists for {}:{}",
+                        pr.head.repo.owner.login, pr.head.r#ref
+                    );
+                    if !dont_stop_at_first_existing {
+                        eprintln!("Ran into already existing PR, stopping.");
+                        break;
+                    }
+                }
+                _ => return Err(err),
+            },
+        }
+    }
+
+    Ok(())
 }
 
 fn sync_branches(
@@ -414,11 +502,20 @@ struct PullRequestBase {
 }
 
 #[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+enum PullRequestState {
+    Open,
+    Closed,
+}
+
+#[derive(serde::Deserialize, Debug)]
 struct PullRequest {
     html_url: String,
     title: String,
     head: PullRequestBase,
     base: PullRequestBase,
+    user: SimpleUser,
+    state: PullRequestState,
 }
 
 /// Get PR object from PR number
@@ -478,6 +575,127 @@ fn create_pr(
         .send()?
         .error_for_status_with_body()?
         .json()?)
+}
+
+fn get_pulls_iter<'a>(
+    http_client: &'a reqwest::blocking::Client,
+    token: &'a InstallationOrUserToken,
+    repo_full_name: &String,
+) -> impl Iterator<Item = Result<PullRequest>> {
+    enum State {
+        FirstUrl(String),
+        GotLinkHeader(reqwest::header::HeaderValue),
+        Stop,
+    }
+    struct Iter<'a> {
+        http_client: &'a reqwest::blocking::Client,
+        token: &'a InstallationOrUserToken,
+        state: State,
+    }
+    impl std::iter::FusedIterator for Iter<'_> {}
+    impl Iterator for Iter<'_> {
+        type Item = Result<Vec<PullRequest>>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let url = match self.state {
+                State::FirstUrl(ref url) => url,
+                State::GotLinkHeader(ref header_value) => {
+                    match get_next_link_from_header(header_value) {
+                        Ok(Some(url)) => url,
+                        Ok(None) => {
+                            self.state = State::Stop;
+                            return None;
+                        }
+                        Err(err) => {
+                            let err = err.context(format!(
+                                "failed to parse \"link\" header: {header_value:?}"
+                            ));
+                            self.state = State::Stop;
+                            return Some(Err(err));
+                        }
+                    }
+                }
+                State::Stop => return None,
+            };
+            eprintln!("Fetching {url}...");
+            let res = self
+                .http_client
+                .get(url)
+                .bearer_auth(&self.token.0)
+                .send()
+                .context("failed to send request for PRs")
+                .and_then(ResponseErrorWithBody::error_for_status_with_body)
+                .context("request for PRs failed");
+            let response = match res {
+                Err(err) => {
+                    self.state = State::Stop;
+                    return Some(Err(err));
+                }
+                Ok(response) => response,
+            };
+            self.state = match response.headers().get("link") {
+                Some(header) => State::GotLinkHeader(header.clone()),
+                None => State::Stop,
+            };
+            match response.json() {
+                Ok(prs) => Some(Ok(prs)),
+                Err(err) => {
+                    self.state = State::Stop;
+                    Some(Err(err).context("couldn't parse JSON response"))
+                }
+            }
+        }
+    }
+    use itertools::Itertools;
+    Iter {
+        http_client,
+        token,
+        state: State::FirstUrl(format!(
+            "https://api.github.com/repos/{repo_full_name}/pulls"
+        )),
+    }
+    .flatten_ok()
+}
+
+fn get_next_link_from_header(h: &reqwest::header::HeaderValue) -> Result<Option<&str>> {
+    // example header:
+    // link: <https://api.github.com/repositories/4542716/pulls?page=2>; rel="next", <https://api.github.com/repositories/4542716/pulls?page=359>; rel="last"
+    let link_header = h.to_str().context("failed to convert header to string")?;
+    for part in link_header.split(", ") {
+        let Ok([link_part, rel_part]): Result<[_; 2], _> =
+            part.split("; ").collect::<Vec<_>>().try_into()
+        else {
+            return Err(anyhow!(
+                "header part doesn't split into link and rel parts: {part}"
+            ));
+        };
+        if !link_part.starts_with('<') || !link_part.ends_with('>') {
+            return Err(anyhow!(
+                "link is not surrounded by angle brackets: {link_part}"
+            ));
+        }
+        let link = &link_part[1..link_part.len() - 1];
+        if !rel_part.starts_with("rel=\"") || !rel_part.ends_with('"') {
+            return Err(anyhow!("cannot parse rel value: {rel_part}"));
+        }
+        let rel = &rel_part[5..rel_part.len() - 1];
+        if rel == "next" {
+            return Ok(Some(link));
+        }
+    }
+    Ok(None)
+}
+
+#[test]
+fn test_get_next_link_from_header() {
+    assert!(matches!(
+        get_next_link_from_header(&reqwest::header::HeaderValue::from_static(
+            r#"<https://api.github.com/repositories/4542716/pulls?page=2>; rel="next", <https://api.github.com/repositories/4542716/pulls?page=359>; rel="last""#
+        )),
+        Ok(Some(
+            url
+        )) if url == "https://api.github.com/repositories/4542716/pulls?page=2"
+    ))
 }
 
 #[derive(serde_repr::Deserialize_repr, Debug, PartialEq)]


### PR DESCRIPTION
Every 5 minutes scan last 100 Nixpkgs PRs, find ones created by a member of CUDA team and mirror it to `nixos-cuda/nixpkgs`. If PR has already been mirrored, then stop.
Note that PRs will only be closed when they are merged in upstream and synced to our fork.

For now use hydra-channel-updater app's key. If that's OK, we should add it permissions to create PRs. If it's not, we should create another app for this.
