### PR TITLE
hydra: fix sync-cuda-prs

### DIFF
--- a/hosts/hydra/sync-cuda-prs.nix
+++ b/hosts/hydra/sync-cuda-prs.nix
@@ -38,7 +38,7 @@ let
 
       # body for new PRs
       "--body"
-      "Clone of {html_url} for CI"
+      "'Clone of {html_url} for CI'"
 
       # scan last 100 PRs
       "--top"


### PR DESCRIPTION
```
[root@hydra:~]# systemctl status sync-cuda-prs
× sync-cuda-prs.service
     Loaded: loaded (/etc/systemd/system/sync-cuda-prs.service; linked; preset: ignored)
     Active: failed (Result: exit-code) since Wed 2026-05-13 10:23:26 CEST; 4s ago
 Invocation: 98834e6f4c3346a4a37e5f8df5734586
TriggeredBy: ● sync-cuda-prs.timer
    Process: 867887 ExecStart=/nix/store/79c1hvr6vrigxw307dq9wp0557a0gvmd-unit-script-sync-cuda-prs-start/bin/sync-cuda-prs-start (code=exited, status=2)
   Main PID: 867887 (code=exited, status=2)
         IP: 0B in, 0B out
         IO: 0B read, 0B written
   Mem peak: 2.4M
        CPU: 13ms

May 13 10:23:26 hydra systemd[1]: Starting sync-cuda-prs.service...
May 13 10:23:26 hydra sync-cuda-prs-start[867889]: error: unexpected argument 'of' found
May 13 10:23:26 hydra sync-cuda-prs-start[867889]: Usage: helpers sync-prs [OPTIONS]
May 13 10:23:26 hydra sync-cuda-prs-start[867889]: For more information, try '--help'.
May 13 10:23:26 hydra systemd[1]: sync-cuda-prs.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
May 13 10:23:26 hydra systemd[1]: sync-cuda-prs.service: Failed with result 'exit-code'.
May 13 10:23:26 hydra systemd[1]: Failed to start sync-cuda-prs.service.

``` 