### PR TITLE
hydra: Add zstd to hydra-server's PATH

### DIFF
--- a/hosts/hydra/hydra/default.nix
+++ b/hosts/hydra/hydra/default.nix
@@ -102,6 +102,10 @@ in
         };
       };
     };
+
+  # hydra-server uses zstd binary to serve logs when they are compressed with zstd
+  systemd.services.hydra-server.path = [ pkgs.zstd ];
+
   networking.firewall.allowedTCPPorts = [
     80
     443


### PR DESCRIPTION
Weirdly it wasn't added there by the commit that added zstd compression support to the upstream module.

Without this, we're getting

```
hydra-server[3594125]: sh: line 1: zstd: command not found
```

every time someone tries to fetch log file compressed with zstd.

Fixes https://github.com/nixos-cuda/infra/issues/123
Proposed to upstream: https://github.com/NixOS/nixpkgs/pull/547786
