### PR TITLE
hydra: remove redundant zstd from hydra-server path

### DIFF
--- a/hosts/hydra/hydra/default.nix
+++ b/hosts/hydra/hydra/default.nix
@@ -103,9 +103,6 @@ in
       };
     };
 
-  # hydra-server uses zstd binary to serve logs when they are compressed with zstd
-  systemd.services.hydra-server.path = [ pkgs.zstd ];
-
   networking.firewall.allowedTCPPorts = [
     80
     443


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/549815 is now integrated
